### PR TITLE
PurchaseListState fixed

### DIFF
--- a/src/components/clients-components/OrderDetails.tsx
+++ b/src/components/clients-components/OrderDetails.tsx
@@ -164,6 +164,7 @@ const OrderDetails = () => {
       dispatch(
         completePurchase({
           date: currentDate.toISOString(),
+          purchase: currentPurchase
         })
       );
 

--- a/src/components/clients-components/ProviderCard.tsx
+++ b/src/components/clients-components/ProviderCard.tsx
@@ -11,7 +11,7 @@ import {
 import { Provider } from "../../models/UsersModels";
 
 interface ProviderCardProps {
-  provider: Provider;
+  provider: Provider | null;
 }
 
 const ProviderCard: React.FC<ProviderCardProps> = ({ provider }) => {

--- a/src/models/UsersModels.tsx
+++ b/src/models/UsersModels.tsx
@@ -126,3 +126,15 @@ interface Purchase {
 }
 
 export type { Purchase };
+
+interface PurchaseListState {
+  currentPurchaseProvider: Provider | null;
+  currentPurchase: Purchase;
+  purchases: Purchase[];
+}
+
+type SetProviderPayload = {
+  provider: Provider;
+};
+
+export type { PurchaseListState, SetProviderPayload };

--- a/src/redux/PurchaseListSlice.tsx
+++ b/src/redux/PurchaseListSlice.tsx
@@ -5,17 +5,9 @@ import {
   Provider,
   Client,
   Purchase,
+  PurchaseListState,
+  SetProviderPayload
 } from "../models/UsersModels";
-
-
-interface PurchaseListState {
-  currentPurchaseProvider: Provider | null;
-  currentPurchase: Purchase;
-  purchases: Purchase[];
-}
-type SetProviderPayload = {
-  provider: Provider;
-};
 
 const initialState: PurchaseListState = {
   currentPurchaseProvider: null,
@@ -186,9 +178,9 @@ const purchaseListSlice = createSlice({
       state.currentPurchase.totalPurchase = action.payload;
     },
 
-    completePurchase: (state, action: PayloadAction<{ date: string }>) => {
+    completePurchase: (state, action: PayloadAction<{ date: string; purchase: Purchase }>) => {
       const currentClient = state.currentPurchase.client;
-
+    
       state.purchases.push({
         ...state.currentPurchase,
         date: action.payload.date,
@@ -201,7 +193,7 @@ const purchaseListSlice = createSlice({
         totalPurchase: 0,
         date: "",
       };
-    },
+    },    
   },
 });
 


### PR DESCRIPTION
En la presente Pull Request:

Se solucionó el error que se encontró al importar al componente `RootStateTypes.tsx` la interfaz de PurchaseListState, ya que se implementaba anteriormente en el slice `PurchaseListSlice.tsx` y debía incluírse en el componente de interfaces llamado `UsersModels.tsx`

Se aplicaron las modificaciones pertinentes y se solucionó el error. Además se realizaron pruebas exhaustivas y no se encuentra el error.

Se aguarda a la revisión de la presente PR, y su correspondiente Merge a la rama Main.